### PR TITLE
Update ReforgedPrice.java

### DIFF
--- a/reforged/src/main/java/net/impactdev/gts/reforged/price/ReforgedPrice.java
+++ b/reforged/src/main/java/net/impactdev/gts/reforged/price/ReforgedPrice.java
@@ -254,6 +254,10 @@ public class ReforgedPrice implements SpongePrice<ReforgedPrice.PokemonPriceSpec
                     return false;
                 }
             }
+            
+            if (pokemon.hasSpecFlag( "untradeable" )) {
+                return false;
+            }
 
             return pokemon.getSpecies().equals(this.species) &&
                     pokemon.getSpecies().getFormEnum(pokemon.getForm()).equals(this.species.getFormEnum(this.form)) &&


### PR DESCRIPTION
Disallowing "Untradeable" pokemon from capable of being used as a price option.